### PR TITLE
Enable GD while already installed

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -33,6 +33,7 @@ RUN apt-get update &&           \
     --no-install-recommends &&  \
     apt-get clean &&            \
     rm -rf /var/lib/apt/lists/*
+RUN docker-php-ext-configure gd --with-jpeg-dir
 RUN docker-php-ext-install -j$(nproc)   \
     gd                                  \
     intl                                \

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -33,7 +33,7 @@ RUN apt-get update &&           \
     --no-install-recommends &&  \
     apt-get clean &&            \
     rm -rf /var/lib/apt/lists/*
-RUN docker-php-ext-configure gd --with-jpeg-dir
+RUN docker-php-ext-configure gd --with-jpeg=/usr/include/
 RUN docker-php-ext-install -j$(nproc)   \
     gd                                  \
     intl                                \
@@ -44,6 +44,7 @@ RUN docker-php-ext-install -j$(nproc)   \
     opcache                             \
     bcmath                              \
     sockets
+RUN docker-php-ext-enable gd mysqli curl
 # copy the Composer PHAR from the Composer image into the PHP image
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 WORKDIR /opt/code

--- a/code/test-gd.php
+++ b/code/test-gd.php
@@ -1,0 +1,16 @@
+<?php
+if (extension_loaded('gd') && function_exists('gd_info')) {
+    echo "PHP GD library is installed on your web server <br>";
+} else {
+    echo "PHP GD library is NOT installed on your web server <br>";
+}
+
+$infos = gd_info();
+foreach ($infos as $key => $value) {
+    // $arr[3] wird mit jedem Wert von $arr aktualisiert...
+    echo "{$key} => {$value} <br>";
+}
+
+// while (list ($key, $val) = each ($a)) {
+//   echo "$key -> $val <br>";
+// }

--- a/docker-config-gd.patch
+++ b/docker-config-gd.patch
@@ -1,0 +1,12 @@
+diff --git a/.docker/Dockerfile b/.docker/Dockerfile
+index 093a509..7c422dc 100644
+--- a/.docker/Dockerfile
++++ b/.docker/Dockerfile
+@@ -33,6 +33,7 @@ RUN apt-get update &&           \
+     --no-install-recommends &&  \
+     apt-get clean &&            \
+     rm -rf /var/lib/apt/lists/*
++RUN docker-php-ext-configure gd --with-jpeg-dir
+ RUN docker-php-ext-install -j$(nproc)   \
+     gd                                  \
+     intl                                \


### PR DESCRIPTION
We have already installed the libraries, so why we don't enable GD support?